### PR TITLE
Changed behaviour so that commit date and author reflects revision information

### DIFF
--- a/gitdriver.py
+++ b/gitdriver.py
@@ -63,10 +63,19 @@ def main():
             for chunk in r.iter_content():
                 fd.write(chunk)
 
+        # Prepare environment variables to change commit time
+        env = os.environ.copy()
+        env['GIT_COMMITTER_DATE'] = rev['modifiedDate']
+        env['GIT_AUTHOR_DATE'] = rev['modifiedDate']
+        env['GIT_COMMITTER_NAME'] = rev['lastModifyingUserName']
+        env['GIT_AUTHOR_NAME'] = rev['lastModifyingUserName']
+        env['GIT_COMMITTER_EMAIL'] = rev['lastModifyingUserName']
+        env['GIT_AUTHOR_EMAIL'] = rev['lastModifyingUserName']
+
         # Commit changes to repository.
         subprocess.call(['git', 'add', 'content'])
         subprocess.call(['git', 'commit', '-m',
-            'revision from %s' % rev['modifiedDate']])
+            'revision from %s' % rev['modifiedDate']], env=env)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
There might be some discussion to be had on 
* Whether we use just "author" and not "committer", which seems to better reflect what the two terms mean, but it less useful in practice.
* What we want to do about the email addresses - you cannot retrieve them from the Drive API.