### PR TITLE
Add requirements.txt and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 gd.conf
 venv
-drive.pyc
+*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+gd.conf
+venv
+drive.pyc

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+PyYAML==3.11
+requests==2.9.1
+wheel==0.24.0


### PR DESCRIPTION
Allows easy installation of dependencies via `pip install -r requirements.txt` (would recommend putting this in readme too if you're into it), and ensures the `gd.conf` file (with secret credentials in it) isn't accidentally committed to version control.